### PR TITLE
Changed the loading of individual lua libraries to be wrapped via lua_call

### DIFF
--- a/lib/rufus/lua/lib.rb
+++ b/lib/rufus/lua/lib.rb
@@ -64,6 +64,7 @@ module Lua
 
     attach_function :luaL_openlibs, [ :pointer ], :void
 
+    attach_function :lua_call, [ :pointer, :int, :int ], :void
     %w[ base package string table math io os debug ].each do |libname|
       attach_function "luaopen_#{libname}", [ :pointer ], :void
     end

--- a/lib/rufus/lua/state.rb
+++ b/lib/rufus/lua/state.rb
@@ -385,7 +385,7 @@ module Rufus::Lua
           Lib.luaL_openlibs(@pointer)
           break
         else
-          Lib.send("luaopen_#{libname}", @pointer)
+          load_individual_library(libname)
         end
       end
 
@@ -587,6 +587,25 @@ module Rufus::Lua
       raise "State got closed, cannot proceed" unless @pointer
       Lib.lua_gc(@pointer, LUA_GCRESTART, 0)
     end
+
+  private
+
+    # #load_individual_library(libname) - load a lua library via lua_call().
+    #
+    # This is needed because is the Lua 5.1 Reference Manual Section 5
+    # (http://www.lua.org/manual/5.1/manual.html#5) it says:
+    #
+    # "The luaopen_* functions (to open libraries) cannot be called
+    # directly, like a regular C function. They must be called through
+    # Lua, like a Lua function."
+    #
+    # "..you must call them like any other Lua C function, e.g., by using lua_call."
+    def load_individual_library(libname)
+      Lib.lua_pushcclosure(@pointer, lambda { |pointer| Lib.send("luaopen_#{libname}", @pointer) }, 0)
+      Lib.lua_pushstring(@pointer, (libname.to_s == "base" ? "" : libname.to_s))
+      Lib.lua_call(@pointer, 1, 0)
+    end
+
   end
 end
 


### PR DESCRIPTION
I am trying to sandbox lua inside of a rails app by blocking off access to io._, os._ and debug.*. I did this by telling State.new I wanted only certain libraries to be loaded:

``` ruby
state = Rufus::Lua::State.new(%w[base table string math package])
```

However, that threw an error:

```
PANIC: unprotected error in call to Lua API (no calling environment)
```

I saw this on Mac OS 10.9 with lua 5.1.5 built from homebrew, and on Linux (kernel 3.8.11 x64 on Heroku Cedar) using prebuilt lua 5.1.4 binaries.  I traced that error to be caused by an api change: http://lua-users.org/lists/lua-l/2007-04/msg00382.html.

To solve it, I wrapped the call to load the libraries inside of a call to the lua_call function.

Side note: that error was only thrown when I tried to load the package, io, os and debug libraries. If I told State.new to just load base, table, string and math, the older call did work. It was only in trying to load the other libraries where I saw this error. 
