### PR TITLE
Remove duplicate VERSION declaration

### DIFF
--- a/lib/rufus/lua/state.rb
+++ b/lib/rufus/lua/state.rb
@@ -25,8 +25,6 @@
 
 module Rufus::Lua
 
-  VERSION = '1.1.0'
-
   #
   # An error class for this gem/library.
   #


### PR DESCRIPTION
Remove duplicate VERSION declaration to eliminate annoying warning
