### PR TITLE
Properly coerce NilClass into Lua nil objects

### DIFF
--- a/lib/rufus/lua/utils.rb
+++ b/lib/rufus/lua/utils.rb
@@ -48,6 +48,7 @@ module Rufus::Lua
       when Float then o.to_s
       when TrueClass then o.to_s
       when FalseClass then o.to_s
+      when NilClass then 'nil'
 
       when Hash then to_lua_table_s(o)
       when Array then to_lua_table_s(o)

--- a/spec/utils_spec.rb
+++ b/spec/utils_spec.rb
@@ -31,6 +31,14 @@ describe Rufus::Lua do
         '{ ["a"] = "A", ["b"] = 2 }'
       )
     end
+
+    it 'turns Ruby NilClass into Lua nil representation' do
+      expect(Rufus::Lua.to_lua_s(
+        {'a' => nil}
+      )).to eq(
+        '{ ["a"] = nil }'
+      )
+    end
   end
 end
 


### PR DESCRIPTION
While working with some ruby hashes I came across it crashing because it didn't know about NilClass.

This just makes it use the lua `nil` since `nil.to_s` would return `""` in ruby.
