### PR TITLE
Fix broken examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ s = Rufus::Lua::State.new
 s.function 'key_up' do |table|
   table.inject({}) do |h, (k, v)|
     h[k.to_s.upcase] = v
+    h
   end
 end
 
@@ -128,11 +129,11 @@ require 'rufus-lua'
 s = Rufus::Lua::State.new
 
 s.eval("rubies = {}")
-s.function 'add' do |x, y|
+s.function 'rubies.add' do |x, y|
   x + y
 end
 
-s.eval("rubies.add(1, 2)")
+p s.eval("return rubies.add(1, 2)")
   # => 3.0
 
 s.close
@@ -150,7 +151,7 @@ s.function 'rubies.add' do |x, y|
   x + y
 end
 
-s.eval("rubies.add(1, 2)")
+p s.eval("return rubies.add(1, 2)")
   # => 3.0
 
 s.close


### PR DESCRIPTION
I've tried to examples in README.md but some of them can't execute correctly.
e.g.)

myluacode2.rb:
```ruby
require 'rufus-lua'

s = Rufus::Lua::State.new

s.function 'key_up' do |table|
  table.inject({}) do |h, (k, v)|
    h[k.to_s.upcase] = v
  end
end

p s.eval(%{
  local table = { CoW = 2, pigs = 3, DUCKS = 'none' }
  return key_up(table) -- calling Ruby from Lua...
}).to_h
  # => { 'COW' => 2.0, 'DUCKS => 'none', 'PIGS' => 3.0 }

s.close
```

```console
$ ruby myluacode2.rb
Traceback (most recent call last):
	11: from myluacode2.rb:11:in `<main>'
	10: from /home/aho/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rufus-lua-1.1.5/lib/rufus/lua/state.rb:433:in `eval'
	 9: from /home/aho/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rufus-lua-1.1.5/lib/rufus/lua/state.rb:73:in `loadstring_and_call'
	 8: from /home/aho/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rufus-lua-1.1.5/lib/rufus/lua/state.rb:303:in `pcall'
	 7: from /home/aho/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rufus-lua-1.1.5/lib/rufus/lua/state.rb:303:in `lua_pcall'
	 6: from /home/aho/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rufus-lua-1.1.5/lib/rufus/lua/state.rb:528:in `block in function'
	 5: from myluacode2.rb:6:in `block in <main>'
	 4: from myluacode2.rb:6:in `inject'
	 3: from /home/aho/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rufus-lua-1.1.5/lib/rufus/lua/objects.rb:135:in `each'
	 2: from /home/aho/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rufus-lua-1.1.5/lib/rufus/lua/objects.rb:135:in `each'
	 1: from /home/aho/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/rufus-lua-1.1.5/lib/rufus/lua/objects.rb:135:in `block in each'
myluacode2.rb:7:in `block (2 levels) in <main>': undefined method `[]=' for 2.0:Float (NoMethodError)
```

I confirmed that they are bugs in the examples, not in the library.
